### PR TITLE
Feature/add iam resources for timeboxed access

### DIFF
--- a/ansible-includes/aws-account-basic-setup.yml
+++ b/ansible-includes/aws-account-basic-setup.yml
@@ -163,19 +163,7 @@
         state: update
       with_items: "{{ aws_users }}"
       when: aws_users is defined
-#      register: async_assignuserstogroups
-#      async: 7200
-#      poll: 0
       tags: [ 'bastion', 'create_users' ]
-#    - name: Wait for async_assignuserstogroups tasks to finish
-#      async_status: jid={{ item.ansible_job_id }}
-#      register: async_assignuserstogroups_jobs
-#      until: async_assignuserstogroups_jobs.finished
-#      retries: 300
-#      with_items: "{{ async_assignuserstogroups.results }}"
-#      when: aws_users is defined
-#      tags: [ 'bastion', 'create_users' ]
-
 
     ### There might be environments (i.e. tst) that have no associated account, that's OK
     - name: Create policies for Assume<Role>-<env> and assign to the respective groups

--- a/ansible-includes/aws-account-basic-setup.yml
+++ b/ansible-includes/aws-account-basic-setup.yml
@@ -152,6 +152,32 @@
       with_items: "{{ async_createawsusers.results }}"
       tags: [ 'bastion', 'create_users' ]
 
+    - name: Create inline policy for user to allow to assume timeboxed roles on all accounts
+      iam_policy:
+        aws_access_key: "{{ assumed_role.sts_creds.access_key }}"
+        aws_secret_key: "{{ assumed_role.sts_creds.secret_key }}"
+        security_token: "{{ assumed_role.sts_creds.session_token }}"
+        iam_type: user
+        iam_name: "{{ item.name }}"
+        policy_name: "assume-timeboxed-roles"
+        state: "{{ item.state | default('present') }}"
+        policy_json: "{{ lookup('template', 'templates/bastion-user-policy-assume-timeboxed-role.j2') }}"
+      with_items: "{{ aws_users }}"
+      when: aws_users is defined
+      loop_control:
+        pause: 1
+      register: async_createawsusers_inline_policy_timeboxed
+      async: 7200
+      poll: 0
+      tags: [ 'bastion', 'create_users' ]
+    - name: Wait for async_createawsusers tasks to finish
+      async_status: jid={{ item.ansible_job_id }}
+      register: async_createawsusers_jobs_inline_policy_timeboxed
+      until: async_createawsusers_jobs_inline_policy_timeboxed.finished
+      retries: 300
+      with_items: "{{ async_createawsusers_inline_policy_timeboxed.results }}"
+      tags: [ 'bastion', 'create_users' ]
+
     - name: Assign user to groups in the bastion account
       iam:
         aws_access_key: "{{ assumed_role.sts_creds.access_key }}"

--- a/templates/CloudFormationTemplates/cfn-security-for-subaccount-iam.yml
+++ b/templates/CloudFormationTemplates/cfn-security-for-subaccount-iam.yml
@@ -59,6 +59,7 @@ Resources:
           - Effect: Allow
             Action:
               - ec2:Describe*
+              - ec2-instance-connect:*
             Resource:
               - arn:aws:ec2:{{ item.item.region | default('eu-central-1') }}:{{ item.item.account_id }}:instance/*
           - Effect: Allow
@@ -66,11 +67,13 @@ Resources:
               - ssm:StartSession
             Resource:
               - arn:aws:ec2:{{ item.item.region | default('eu-central-1') }}:{{ item.item.account_id }}:instance/*
+              - arn:aws:ssm:eu-central-1::document/AWS-StartSSHSession
           - Effect: Allow
             Action:
               - ssm:TerminateSession
             Resource:
               - arn:aws:ssm:*:*:session/${aws:username}-*
+              - arn:aws:ssm:*:*:session/*${aws:userid}-*
 
   LambdaBasicExecutionRole:
     Type: AWS::IAM::Role

--- a/templates/CloudFormationTemplates/cfn-security-for-subaccount-iam.yml
+++ b/templates/CloudFormationTemplates/cfn-security-for-subaccount-iam.yml
@@ -48,6 +48,30 @@ Resources:
             Resource:
               - "*"
 
+  IxorSSMSessionPolicy:
+    Type: AWS::IAM::ManagedPolicy
+    Properties:
+      ManagedPolicyName: "SSMSession"
+      Path: "/IxorSSM/"
+      PolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Action:
+              - ec2:Describe*
+            Resource:
+              - arn:aws:ec2:{{ item.item.region | default('eu-central-1') }}:{{ item.item.account_id }}:instance/*
+          - Effect: Allow
+            Action:
+              - ssm:StartSession
+            Resource:
+              - arn:aws:ec2:{{ item.item.region | default('eu-central-1') }}:{{ item.item.account_id }}:instance/*
+          - Effect: Allow
+            Action:
+              - ssm:TerminateSession
+            Resource:
+              - arn:aws:ssm:*:*:session/${aws:username}-*
+
   LambdaBasicExecutionRole:
     Type: AWS::IAM::Role
     Properties:

--- a/templates/bastion-user-policy-assume-timeboxed-role.j2
+++ b/templates/bastion-user-policy-assume-timeboxed-role.j2
@@ -1,0 +1,33 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "1",
+      "Effect": "Allow",
+      "Action": [
+        "sts:AssumeRole"
+      ],
+      "Resource": [
+        "arn:aws:iam::*:role/IxorSSM/{{ item.name }}/*"
+      ],
+      "Condition": {
+        "Bool": {
+          "aws:MultiFactorAuthPresent": "true",
+          "aws:SecureTransport": "true"
+        },
+        "NumericLessThan": {
+          "aws:MultiFactorAuthAge": "43200"
+        }
+      }
+    },
+    {
+      "Sid": "2",
+      "Effect": "Allow",
+      "Action": [
+        "sts:GetSessionToken"
+      ],
+      "Resource": [
+        "arn:aws:iam::*:role/IxorSSM/{{ item.name }}/*"            ]
+    }
+  ]
+}


### PR DESCRIPTION
Create all IAM resources on bastion account and subaccounts to allow creation of  per-user timeboxed roles.
These roles are created on request, are only valid inside a given timeframe and can be assumed only by that specific
user with its bastion credentials and MFA.