### PR TITLE
feature: Add budget alerts to accounts

### DIFF
--- a/ansible-includes/aws-account-basic-setup.yml
+++ b/ansible-includes/aws-account-basic-setup.yml
@@ -417,7 +417,16 @@
       with_items:
         - "{{ subaccounts }}"
       when: "bastion_account.account_id != item.account_id and ( subaccount_limit == 'all' or item.name.startswith(subaccount_limit) )"
-      tags: [ 'subaccounts', 'passwordpolicy', 'accountalias', 'createroles', 'organization', 'keypair', 'servicelinkedrole', 'ssm_parameters' ]
+      tags:
+        - 'subaccounts'
+        - 'passwordpolicy'
+        - 'accountalias'
+        - 'createroles'
+        - 'organization'
+        - 'keypair'
+        - 'servicelinkedrole'
+        - 'ssm_parameters'
+        - 'budget'
 
     - name: Set password policy rules on the sub accounts
       command: >
@@ -738,3 +747,45 @@
           when: "deployscript.stat.exists"
       tags: [ 'html', 'create_users' ]
 
+    - name: Block for budget alerts on the subaccounts
+      block:
+        - name: "Create CFN template from Ansible template for the AWS Config setup on the subaccounts"
+          template:
+            src: "CloudFormationTemplates/cfn-budget-alerts.yml"
+            dest: "{{ generated_files_dir | default('generated-files') }}/cfn-{{ organization.name }}-budget-alerts-{{ item.item.account_id }}.yml"
+          with_items: "{{ assumed_role_subaccount_single.results }}"
+          when: "skip_aws_config is undefined or not skip_aws_config"
+
+        - name: Linter check for the budget alerts on the subaccounts
+          shell: |
+            cfn-lint --ignore-checks={{ lint_ignore_list | default('') }} "{{ generated_files_dir | default('generated-files') }}/cfn-{{ organization.name }}-budget-alerts-{{ item.item.account_id }}.yml"
+          with_items: "{{ assumed_role_subaccount_single.results }}"
+
+        - name: Create/Update Budget Alert Stack on all accounts
+          cloudformation:
+            aws_access_key: "{{ item.sts_creds.access_key }}"
+            aws_secret_key: "{{ item.sts_creds.secret_key }}"
+            security_token: "{{ item.sts_creds.session_token }}"
+            region: "{{ default_region | default('eu-central-1') }}"
+            stack_name: "{{ cfn_org_name }}BudgetAlerts"
+            state: "present"
+            disable_rollback: false
+            template: "{{ generated_files_dir | default('generated-files') }}/cfn-{{ organization.name }}-budget-alerts-{{ item.item.account_id }}.yml"
+          with_items:
+            - "{{ assumed_role_subaccount_single.results }}"
+          register: async_createbudgetalertscloudformationstack
+          async: 7200
+          poll: 0
+          when: "skip_aws_config is undefined or not skip_aws_config"
+
+        ### Wait
+        - name: Wait for async_createbudgetalertscloudformationstack tasks to finish
+          async_status: jid={{ item.ansible_job_id }}
+          register: async_createbudgetalertscloudformationstack_jobs
+          until: async_createbudgetalertscloudformationstack_jobs.finished
+          retries: 300
+          with_items: "{{ async_createbudgetalertscloudformationstack.results | default([]) }}"
+          when: "skip_aws_config is undefined or not skip_aws_config"
+
+      when: "budget_alerts is defined and budget_alerts.notification_emails is defined"
+      tags: [ 'subaccounts', 'budget' ]

--- a/templates/CloudFormationTemplates/cfn-budget-alerts.yml
+++ b/templates/CloudFormationTemplates/cfn-budget-alerts.yml
@@ -1,0 +1,48 @@
+---
+{% set budget_alert_spend = "200" %}
+{% set budget_alert_notification_emails = [] %}
+
+{% if item.item.budget_alerts is defined and item.item.budget_alerts.spend is defined %}
+{%   set budget_alert_spend = item.item.budget_alerts.spend %}
+{% elif budget_alerts is defined and budget_alerts.spend is defined %}
+{%   set budget_alert_spend = budget_alerts.spend %}
+{% else %}
+{%   set budget_alert_spend = 200 %}
+{% endif %}
+
+{% if item.item.budget_alerts is defined and item.item.budget_alerts.notification_emails is defined %}
+{%   set budget_alert_notification_emails = item.item.budget_alerts.notification_emails %}
+{% elif budget_alerts is defined and budget_alerts.notification_emails is defined %}
+{%   set budget_alert_notification_emails = budget_alerts.notification_emails %}
+{% endif %}
+
+Description: "Budget Alerts"
+Resources:
+  BudgetAlerts:
+    Type: "AWS::Budgets::Budget"
+    Properties:
+      Budget:
+        BudgetLimit:
+          Amount: {{ budget_alert_spend }}
+          Unit: USD
+        TimeUnit: MONTHLY
+        BudgetType: COST
+      NotificationsWithSubscribers:
+        - Notification:
+            NotificationType: ACTUAL
+            ComparisonOperator: GREATER_THAN
+            Threshold: 80
+          Subscribers:
+{% for email in budget_alert_notification_emails | default([]) %}
+            - SubscriptionType: EMAIL
+              Address: "{{ email }}"
+{% endfor %}
+        - Notification:
+            NotificationType: FORECASTED
+            ComparisonOperator: GREATER_THAN
+            Threshold: 80
+          Subscribers:
+{% for email in budget_alert_notification_emails | default([]) %}
+            - SubscriptionType: EMAIL
+              Address: "{{ email }}"
+{% endfor %}


### PR DESCRIPTION
Requires these properties in global account config or in account config to overrids:

```
budget_alerts:
  spend: 200
  notification_emails:
    - mail1@domain.com
    - mail1@domain.com
```